### PR TITLE
Update dependencies to fix build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,11 +18,11 @@
   ],
   "dependencies": {
     "purescript-bifunctors": "0.0.4",
-    "purescript-either": "0.1.2",
-    "purescript-exceptions": "0.2.0",
+    "purescript-either": "0.1.3",
+    "purescript-exceptions": "0.2.1",
     "purescript-foldable-traversable": "0.1.3",
-    "purescript-maybe": "0.2.0",
-    "purescript-tuples": "0.2.0"
+    "purescript-maybe": "0.2.1",
+    "purescript-tuples": "0.2.1"
   },
   "devDependencies": {
     "angular": "1.2.23",


### PR DESCRIPTION
It seems that the version of purescript-monoid that gets included currently (albeit indirectly) is broken, and I get:

```
[error] purescript-monoid/src/Data/Monoid.purs:21: Error in declaration monoidMaybe
[error] No instance found for Prelude.Semigroup (Data.Maybe.Maybe a2878)
[error] instance monoidMaybe :: (Semigroup a) => Monoid (Maybe a) where
[error] ^
```

Updating to the latest versions of the dependencies seems to get it to compile (though I'm not sure if it breaks something else).
