### PR TITLE
Add exports for class members

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -111,7 +111,7 @@
       RootElement :: Element -> RootElement
 
     newtype RootScope a where
-      RootScope :: Scope a -> RootScope
+      RootScope :: Scope a -> RootScope a
 
 
 ### Type Classes
@@ -121,6 +121,8 @@
 
     class Injectable a where
       dependencies :: a -> [String]
+
+    class (Dependency a) <= Service a where
 
 
 ### Type Class Instances
@@ -754,9 +756,9 @@
 ### Types
 
     data ApplyExpr e r a where
-      DefaultApplyExpr :: ApplyExpr
-      StringApplyExpr :: String -> ApplyExpr
-      FnApplyExpr :: (Scope a -> Eff e r) -> ApplyExpr
+      DefaultApplyExpr :: ApplyExpr e r a
+      StringApplyExpr :: String -> ApplyExpr e r a
+      FnApplyExpr :: (Scope a -> Eff e r) -> ApplyExpr e r a
 
     type Event e a b = { defaultPrevented :: Boolean, preventDefault :: Eff e Unit, stopPropagation :: Eff e Unit, name :: String, currentScope :: Scope b, targetScope :: Scope a }
 
@@ -1026,23 +1028,23 @@
     data NgHttp :: !
 
     data RequestData a where
-      NoRequestData :: RequestData
-      StringRequestData :: String -> RequestData
-      ObjectRequestData :: a -> RequestData
+      NoRequestData :: RequestData a
+      StringRequestData :: String -> RequestData a
+      ObjectRequestData :: a -> RequestData a
 
     type RequestDataFn a = { objectRequestData :: a -> RequestData a, stringRequestData :: String -> RequestData a, noRequestData :: RequestData a }
 
     data ResponseData a where
-      NoResponseData :: ResponseData
-      DefaultResponseData :: String -> ResponseData
-      ArrayBufferResponseData :: D.ArrayBuffer -> ResponseData
-      BlobResponseData :: D.Blob -> ResponseData
-      DocumentResponseData :: D.Document -> ResponseData
-      JsonResponseData :: a -> ResponseData
-      TextResponseData :: String -> ResponseData
-      MozBlobResponseData :: D.MozBlob -> ResponseData
-      MozChunkedTextResponseData :: D.MozChunkedText -> ResponseData
-      MozChunkedArrayBufferResponseData :: D.MozChunkedArrayBuffer -> ResponseData
+      NoResponseData :: ResponseData a
+      DefaultResponseData :: String -> ResponseData a
+      ArrayBufferResponseData :: D.ArrayBuffer -> ResponseData a
+      BlobResponseData :: D.Blob -> ResponseData a
+      DocumentResponseData :: D.Document -> ResponseData a
+      JsonResponseData :: a -> ResponseData a
+      TextResponseData :: String -> ResponseData a
+      MozBlobResponseData :: D.MozBlob -> ResponseData a
+      MozChunkedTextResponseData :: D.MozChunkedText -> ResponseData a
+      MozChunkedArrayBufferResponseData :: D.MozChunkedArrayBuffer -> ResponseData a
 
     type ResponseDataFn a = { mozChunkedArrayBufferResponseData :: D.MozChunkedArrayBuffer -> ResponseData a, mozChunkedTextResponseData :: D.MozChunkedText -> ResponseData a, mozBlobResponseData :: D.MozBlob -> ResponseData a, textResponseData :: String -> ResponseData a, jsonResponseData :: a -> ResponseData a, documentResponseData :: D.Document -> ResponseData a, blobResponseData :: D.Blob -> ResponseData a, arrayBufferResponseData :: D.ArrayBuffer -> ResponseData a, defaultResponseData :: String -> ResponseData a, noResponseData :: ResponseData a }
 
@@ -1110,7 +1112,7 @@
 ### Types
 
     newtype PromiseEff e f a b where
-      PromiseEff :: Promise (Eff e a) (Eff f b) -> PromiseEff
+      PromiseEff :: Promise (Eff e a) (Eff f b) -> PromiseEff e f a b
 
 
 ### Type Class Instances

--- a/src/Angular/DI.purs
+++ b/src/Angular/DI.purs
@@ -1,10 +1,10 @@
 module Angular.DI (
-    Dependency
+    Dependency, name
   , Service
   , RootScope(..)
   , RootElement(..)
   , get
-  , Injectable
+  , Injectable, dependencies
   , Annotated()
   , annotate
   ) where
@@ -100,7 +100,7 @@ instance dependencyAttributes :: Dependency Attributes where
   name = "$attrs"
 
 instance dependencyThis :: Dependency (This a) where
-  -- it would be nice to make a dummy service to avoid the special handling 
+  -- it would be nice to make a dummy service to avoid the special handling
   -- in annotate, but there is nowhere to do so
   name = "$this"
 


### PR DESCRIPTION
And another one (we changed it so it's illegal to export a class without also exporting its members, that may change again later if we make the haskell-like `C(x, y)` syntax for class exports like we currently have for type/data constructors).
