### PR TITLE
Tighten up effect types on modifyScope and modifyThis

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -813,7 +813,7 @@
 
     id :: forall a. Scope a -> String
 
-    modifyScope :: forall e f a b. ({  | a } -> Eff f {  | b }) -> Scope a -> ReadWriteEff e Unit
+    modifyScope :: forall e a b. ({  | a } -> Eff e {  | b }) -> Scope a -> ReadWriteEff e Unit
 
     newScope :: forall e a b. Boolean -> Scope a -> ScopeEff e (Scope b)
 
@@ -855,7 +855,7 @@
 
     extendThis :: forall e a b. {  | b } -> This a -> WriteEff e
 
-    modifyThis :: forall e f a b. ({  | a } -> Eff f {  | b }) -> This a -> ReadWriteEff e Unit
+    modifyThis :: forall e a b. ({  | a } -> Eff e {  | b }) -> This a -> ReadWriteEff e Unit
 
     readThis :: forall e a. This a -> ReadEff e a
 

--- a/src/Angular/Scope.purs
+++ b/src/Angular/Scope.purs
@@ -79,7 +79,7 @@ type ReadWriteEff e r = Eff (ngrscope :: NgReadScope, ngwscope :: NgWriteScope |
 
 type ScopeEff e r = Eff (ngscope :: NgScope | e) r
 
-modifyScope :: forall e f a b. ({ | a} -> Eff f { | b }) -> Scope a -> ReadWriteEff e Unit
+modifyScope :: forall e a b. ({ | a} -> Eff e { | b }) -> Scope a -> ReadWriteEff e Unit
 modifyScope k s = do
   s' <- readScope s
   w <- unsafeInterleaveEff $ k s'

--- a/src/Angular/This.purs
+++ b/src/Angular/This.purs
@@ -33,7 +33,7 @@ writeThis = runFn3 writeThisFn
 extendThis :: forall e a b. { | b } -> This a -> WriteEff e
 extendThis = runFn2 extendThisFn
 
-modifyThis :: forall e f a b. ({ | a } -> Eff f { | b }) -> This a -> ReadWriteEff e Unit
+modifyThis :: forall e a b. ({ | a } -> Eff e { | b }) -> This a -> ReadWriteEff e Unit
 modifyThis k t = do
   t' <- readThis t
   w <- unsafeInterleaveEff $ k t'


### PR DESCRIPTION
Fix #19.  Since these run immediately, there is no need to expose the unsafeInterleaveEff.
